### PR TITLE
[Bug] D132601: Latest version of dmd breaks the build (on stretch only)

### DIFF
--- a/argon.d
+++ b/argon.d
@@ -1,4 +1,4 @@
-#!/usr/bin/rdmd --shebang -unittest -g -debug
+#!/usr/bin/rdmd --shebang -unittest -g -debug --main
 
 module argon;
 
@@ -1469,10 +1469,10 @@ public:
         test_robust_failure( filename);
     }
 
-    static if (!existent_file.empty)
+    if (!existent_file.empty)
         test_success(existent_file);
 
-    static if (!nonexistent_file.empty)
+    if (!nonexistent_file.empty)
         test_failure(nonexistent_file);
 
     // Remaining tests can be carried out on all platforms, because everyone
@@ -3623,7 +3623,7 @@ unittest {
         }
     }
 
-    static if (!existent_file.empty && !nonexistent_file.empty) {
+    if (!existent_file.empty && !nonexistent_file.empty) {
         test_named_file_arguments;
         test_positional_file_arguments;
     }


### PR DESCRIPTION
argon.d: SteveK upgraded pris to dmd-bin version 2.077.0-0 and got a build failure that didn't occur with 2.076.1-0:

argon.d(1472): Error: static variable existent_file cannot be read at compile time
argon.d(1472):        called from here: empty(existent_file)
argon.d(1475): Error: static variable nonexistent_file cannot be read at compile time
argon.d(1475):        called from here: empty(nonexistent_file)
argon.d(3626): Error: static variable existent_file cannot be read at compile time
argon.d(3626):        called from here: empty(existent_file)

Removing the keyword static from the affected lines fixes the problem without breaking the build from clean on Jessie.  All the affected lines are within a "unittest" block.  So probably just a premature optimisation and not functionally necessary anyway.

I wanted to run the unit test but struggled to find any explanation of how until I noticed the -unittest on the hash bang line.  ./argon.d said that it needed a bk chmod +x, suggesting that it had never been run this way before, but I tried again only to get:

martind@swiftboat:~/work/cornet3/tools/codconvert2$ ./argon.d
/usr/lib/gcc/x86_64-linux-gnu/4.9/../../../x86_64-linux-gnu/crt1.o: In function `_start':
/build/glibc-6V9RKT/glibc-2.19/csu/../sysdeps/x86_64/start.S:118: undefined reference to `main'
collect2: error: ld returned 1 exit status
--- errorlevel 1
martind@swiftboat:~/work/cornet3/tools/codconvert2$

man rdmd suggested adding --main to the hash bang line.  That seemed to work.  I was suspicious that it wasn't really running the unit test, despite https://tour.dlang.org/tour/en/gems/unittesting assuring me otherwise, so I injected a deliberate failure, which was duly reported.  That gave me reasonable confidence that this was the right fix.  SimonC then returned from a business trip and pointed out that there's a public upstream that might be willing to bless the patch.